### PR TITLE
Apm 3626 fix prod smoketests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,17 @@ clean:
 	@rm -rf build dist
 
 # To prove that the library works against diferent environments we run the same
-# tests against two diferent deployments of the mock-jwks proxy
+# tests against two different deployments of the mock-jwks proxy
 test_proxies = mock-jwks-internal-qa mock-jwks-internal-dev 
 test:
 	@for proxy in  $(test_proxies) ; do \
 		echo $$f; \
 		poetry run pytest tests/test_examples.py -s --proxy-name=$$proxy --api-name=mock-jwks; \
 	done
+
+smoketest:
+	@for proxy in  $(test_proxies) ; do \
+		echo $$f; \
+		poetry run pytest -k 'test_ping_endpoint or test_status_endpoint' --proxy-name=$$proxy --api-name=mock-jwks; \
+	done
+	

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-nhsd-apim"
-version = "3.0.1"
+version = "3.1.0"
 description = "Pytest plugin accessing NHSDigital's APIM proxies"
 authors = ["Ben Strutt <ben.strutt1@nhs.net>", "Adrian Ciobanita <adrian.ciobanita1@nhs.net>"]
 maintainers = ["Ben Strutt <ben.strutt1@nhs.net>", "Adrian Ciobanita <adrian.ciobanita1@nhs.net>"]

--- a/src/pytest_nhsd_apim/apigee_edge.py
+++ b/src/pytest_nhsd_apim/apigee_edge.py
@@ -39,6 +39,12 @@ def _apigee_app_base_url(nhsd_apim_config):
     url = APIGEE_BASE_URL + f"organizations/{org}/developers/{dev}/apps"
     return url
 
+@pytest.fixture(scope="session")
+@log_method
+def _apigee_app_base_url_no_dev(nhsd_apim_config):
+    org = nhsd_apim_config["APIGEE_ORGANIZATION"]
+    url = APIGEE_BASE_URL + f"organizations/{org}/apps"
+    return url
 
 @functools.lru_cache(maxsize=None)
 @log_method
@@ -421,6 +427,7 @@ def nhsd_apim_pre_create_app():
 @log_method
 def _create_test_app(
     _apigee_app_base_url,
+    _apigee_app_base_url_no_dev,
     _apigee_edge_session,
     jwt_public_key_url,
     nhsd_apim_pre_create_app,
@@ -439,7 +446,7 @@ def _create_test_app(
 
     # Retrieving pre-existing app
     if not _test_app_id == "":
-        get_resp = _apigee_edge_session.get(_apigee_app_base_url + "/" + _test_app_id)
+        get_resp = _apigee_edge_session.get(_apigee_app_base_url_no_dev + "/" + _test_app_id)
         err_msg = f"Could not GET TestApp: {_test_app_id}.\tReason: {get_resp.text}"
         assert get_resp.status_code == 200, err_msg
         return get_resp.json()
@@ -483,7 +490,7 @@ def _create_function_scoped_test_app(
 
     # Retrieving pre-existing app
     if not _test_app_id == "":
-        get_resp = _apigee_edge_session.get(_apigee_app_base_url + "/" + _test_app_id)
+        get_resp = _apigee_edge_session.get(_apigee_app_base_url_no_dev + "/" + _test_app_id)
         err_msg = f"Could not GET TestApp: {_test_app_id}.\tReason: {get_resp.text}"
         assert get_resp.status_code == 200, err_msg
         return get_resp.json()

--- a/src/pytest_nhsd_apim/apigee_edge.py
+++ b/src/pytest_nhsd_apim/apigee_edge.py
@@ -513,7 +513,7 @@ def _create_function_scoped_test_app(
         assert delete_resp.status_code == 200, err_msg
     global _TEST_APP
     _TEST_APP = None
-    
+
 
 @pytest.fixture(scope="session")
 @log_method

--- a/src/pytest_nhsd_apim/config.py
+++ b/src/pytest_nhsd_apim/config.py
@@ -23,9 +23,7 @@ _PYTEST_CONFIG = {
         "help": "Proxy under test, should exactly match the name on Apigee.",
         "default": "",  # Must be falsy but not None.
     },
-    "--apigee-access-token": {
-        "help": "Access token to log into apigee edge API, output of get_token"
-    },
+    "--apigee-access-token": {"help": "Access token to log into apigee edge API, output of get_token"},
     "--apigee-organization": {
         "help": "nhsd-nonprod/nhsd-prod.",
         "default": "nhsd-nonprod",
@@ -35,7 +33,8 @@ _PYTEST_CONFIG = {
         "default": "apm-testing-internal-dev@nhs.net",
     },
     "--apigee-app-id": {
-        "help": "Apigee ID of application under test."
+        "help": "Apigee ID of application under test.",
+        "default": "",
     },
     "--jwt-public-key-id": {
         "help": "Key ID ('kid') to select particular key.",

--- a/src/pytest_nhsd_apim/config.py
+++ b/src/pytest_nhsd_apim/config.py
@@ -34,6 +34,9 @@ _PYTEST_CONFIG = {
         "help": "Developer that will own the test app.",
         "default": "apm-testing-internal-dev@nhs.net",
     },
+    "--apigee-app-id": {
+        "help": "Apigee ID of application under test."
+    },
     "--jwt-public-key-id": {
         "help": "Key ID ('kid') to select particular key.",
         "default": "test-1",

--- a/src/pytest_nhsd_apim/config.py
+++ b/src/pytest_nhsd_apim/config.py
@@ -33,8 +33,12 @@ _PYTEST_CONFIG = {
         "default": "apm-testing-internal-dev@nhs.net",
     },
     "--apigee-app-id": {
-        "help": "Apigee ID of application under test.",
-        "default": "",
+        "help": "Apigee ID of application under test. Required for tests in production environments.",
+        "default": "", # Must be falsy but not None.
+    },
+    "--status-endpoint-api-key": {
+        "help": "Used to authenticate calls to proxy's _status endpoint. Required for tests in production environments.",
+        "default": "",  # Must be falsy but not None.
     },
     "--jwt-public-key-id": {
         "help": "Key ID ('kid') to select particular key.",

--- a/src/pytest_nhsd_apim/nhsd_apim_authorization.py
+++ b/src/pytest_nhsd_apim/nhsd_apim_authorization.py
@@ -83,7 +83,7 @@ class Authorization(BaseModel):
 def nhsd_apim_authorization(request, nhsd_apim_api_name):
     """
     Mark your test with a `nhsd_apim_authorization marker`.
-    The call the `nhsd_apim_auth_headers` fixture to access your proxy.
+    Then call the `nhsd_apim_auth_headers` fixture to access your proxy.
 
     >>> import pytest
     >>> import requests

--- a/src/pytest_nhsd_apim/pytest_nhsd_apim.py
+++ b/src/pytest_nhsd_apim/pytest_nhsd_apim.py
@@ -24,6 +24,7 @@ import pytest
 # dependencies of our public fixtures.
 from .apigee_edge import (
     _apigee_app_base_url,
+    _apigee_app_base_url_no_dev,
     _apigee_edge_session,
     _apigee_proxy,
     _create_function_scoped_test_app,

--- a/src/pytest_nhsd_apim/pytest_nhsd_apim.py
+++ b/src/pytest_nhsd_apim/pytest_nhsd_apim.py
@@ -17,15 +17,6 @@ e.g.:
 """
 import pytest
 
-# Import HOOKS so pytest runs them + config fixtures
-from .config import (
-    pytest_addoption,
-    pytest_configure,
-    nhsd_apim_config,
-    nhsd_apim_api_name,
-    nhsd_apim_proxy_name,
-)
-
 # Note: At runtime, pytest does not follow the imports we define in
 # our files. Instead, it just looks amongst all the things it found
 # when it imported our extension.  This means we have to import *all*
@@ -34,10 +25,9 @@ from .config import (
 from .apigee_edge import (
     _apigee_app_base_url,
     _apigee_edge_session,
-    _apigee_edge_session,
     _apigee_proxy,
-    _create_test_app,
     _create_function_scoped_test_app,
+    _create_test_app,
     _identity_service_proxy,
     _identity_service_proxy_name,
     _identity_service_proxy_names,
@@ -46,15 +36,15 @@ from .apigee_edge import (
     _scope,
     _test_app_callback_url,
     _test_app_credentials,
+    _test_app_id,
+    apigee_environment,
     identity_service_base_url,
     nhsd_apim_pre_create_app,
     nhsd_apim_proxy_url,
-    test_app,
     nhsd_apim_test_app,
     nhsd_apim_unsubscribe_test_app_from_all_products,
-    apigee_environment,
+    test_app,
 )
-
 from .auth_journey import (
     _jwt_keys,
     get_access_token_via_signed_jwt_flow,
@@ -66,15 +56,17 @@ from .auth_journey import (
     jwt_public_key_pem,
     jwt_public_key_url,
 )
+
+# Import HOOKS so pytest runs them + config fixtures
+from .config import nhsd_apim_api_name, nhsd_apim_config, nhsd_apim_proxy_name, pytest_addoption, pytest_configure
+from .log import log, log_method
 from .nhsd_apim_authorization import nhsd_apim_authorization
 from .secrets import (
     _keycloak_client_credentials,
     _mock_jwks_api_key,
-    status_endpoint_auth_headers,
     _status_endpoint_api_key,
+    status_endpoint_auth_headers,
 )
-
-from .log import log, log_method
 
 
 @pytest.fixture()

--- a/src/pytest_nhsd_apim/secrets.py
+++ b/src/pytest_nhsd_apim/secrets.py
@@ -10,22 +10,21 @@ import requests
 from .apigee_edge import (
     _apigee_app_base_url,
     _apigee_edge_session,
+    _test_app_id,
+    apigee_environment,
     get_app_credentials_for_product,
     test_app,
-    apigee_environment,
 )
-
 from .log import log, log_method
-
 
 _SESSION = requests.session()
 
 
 @pytest.fixture()
 @log_method
-def _mock_jwks_api_key(_apigee_app_base_url, _apigee_edge_session, test_app, apigee_environment):
+def _mock_jwks_api_key(_apigee_app_base_url, _apigee_edge_session, test_app, apigee_environment, _test_app_id):
     creds = get_app_credentials_for_product(
-        _apigee_app_base_url, _apigee_edge_session, test_app(), f"mock-jwks-{apigee_environment}"
+        _apigee_app_base_url, _apigee_edge_session, test_app(), f"mock-jwks-{apigee_environment}", _test_app_id
     )
     return creds["consumerKey"]
 

--- a/src/pytest_nhsd_apim/secrets.py
+++ b/src/pytest_nhsd_apim/secrets.py
@@ -23,6 +23,9 @@ _SESSION = requests.session()
 @pytest.fixture()
 @log_method
 def _mock_jwks_api_key(_apigee_app_base_url, _apigee_edge_session, test_app, apigee_environment, _test_app_id):
+    # Apps in prod Apigee shouldn't rely on mock-jwks for their api key
+    if apigee_environment in ["int", "prod"]: return ""
+
     creds = get_app_credentials_for_product(
         _apigee_app_base_url, _apigee_edge_session, test_app(), f"mock-jwks-{apigee_environment}", _test_app_id
     )
@@ -40,9 +43,13 @@ _STATUS_ENDPOINT_API_KEY = None
 
 @pytest.fixture()
 @log_method
-def _status_endpoint_api_key(_mock_jwks_api_key, apigee_environment):
+def _status_endpoint_api_key(_mock_jwks_api_key, apigee_environment, nhsd_apim_config):
     global _STATUS_ENDPOINT_API_KEY
-    if _STATUS_ENDPOINT_API_KEY is None:
+
+    # First try retrieving key from config
+    _STATUS_ENDPOINT_API_KEY = nhsd_apim_config.get("STATUS_ENDPOINT_API_KEY", "")
+
+    if _STATUS_ENDPOINT_API_KEY == "":
         resp = _SESSION.get(
             f"https://{apigee_environment}.api.service.nhs.uk/mock-jwks/status-endpoint-api-key",
             headers={"apikey": _mock_jwks_api_key},


### PR DESCRIPTION
Changes to fix test-utils in production environments

Allows users to supply the ID of a pre-existing application that already has relevant product subscriptions. This means that they do not have to programmatically create / destroy test apps, nor their permissions.