### PR TITLE
Strip the trailing slash pydantic adds to the redirect URL

### DIFF
--- a/src/pytest_nhsd_apim/identity_service.py
+++ b/src/pytest_nhsd_apim/identity_service.py
@@ -18,7 +18,7 @@ from lxml import html
 from pydantic import BaseModel, HttpUrl, validator, AfterValidator
 from typing_extensions import Annotated
 
-HttpUrlString = Annotated[HttpUrl, AfterValidator(lambda v: str(v))]
+HttpUrlString = Annotated[HttpUrl, AfterValidator(lambda v: str(v).rstrip("/"))]
 
 
 #### Config models


### PR DESCRIPTION
When the redirect_uri is overridden from the default value, a trailing / is automatically appended causing the auth form request to fail.

The default value is set in the code as:
```
class KeycloakUserConfig(KeycloakConfig):
    ...
    redirect_uri: HttpUrlString = "https://google.com"
```

The default value works fine, it does not have the pydantic validator (HttpUrlString) applied as it's a default value, so generates teh correct URL.

If I override the default i.e.
````
    keycloak_config = KeycloakUserConfig(
        ...
        redirect_uri="https://example.org",
    )
```

Then a trailing slash is added by the validator and the request for the auth form fails (as the redirect URL does not match any more).